### PR TITLE
AP-3713: Bring proto markdown tools from trustero/monorepo

### DIFF
--- a/go/pkg/printer/printer.go
+++ b/go/pkg/printer/printer.go
@@ -1,0 +1,5 @@
+package printer
+
+type Printer interface {
+	Print() string
+}

--- a/go/pkg/printer/printers.go
+++ b/go/pkg/printer/printers.go
@@ -1,0 +1,108 @@
+package printer
+
+import (
+	"fmt"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const dateTimeLayout = "2006-Jan-02"
+
+var PrettyStrconv Strconv = &struct {
+	boolEmoji
+	durationHuman
+	timestampDate
+}{}
+
+var SimpleStrconv Strconv = &struct {
+	simpleTimestamp
+	simpleDuration
+	simpleBool
+}{}
+
+type simpleTimestamp struct{}
+
+func (p *simpleTimestamp) FormatTimestamp(dt *timestamppb.Timestamp) string {
+	if dt == nil || (dt.Nanos == 0 && dt.Seconds == 0) {
+		return ""
+	}
+	return dt.AsTime().Format(dateTimeLayout)
+}
+
+type simpleBool struct{}
+
+func (p *simpleBool) FormatBool(b bool) string {
+	return strconv.FormatBool(b)
+}
+
+type simpleDuration struct{}
+
+func (p *simpleDuration) FormatDuration(dt *durationpb.Duration) string {
+	if dt == nil || (dt.Nanos == 0 && dt.Seconds == 0) {
+		return ""
+	}
+	return dt.AsDuration().String()
+}
+
+type boolEmoji struct{}
+
+func (p *boolEmoji) FormatBool(b bool) string {
+	if b {
+		return ":heavy_check_mark:"
+	}
+	return "-"
+}
+
+type timestampDate struct{}
+
+func (p *timestampDate) FormatTimestamp(dt *timestamppb.Timestamp) string {
+	if dt == nil || (dt.Nanos == 0 && dt.Seconds == 0) {
+		return "-"
+	}
+	return dt.AsTime().Format(dateTimeLayout)
+}
+
+type durationHuman struct{}
+
+func (p *durationHuman) FormatDuration(duration *durationpb.Duration) string {
+	if duration == nil || (duration.Nanos == 0 && duration.Seconds == 0) {
+		return "-"
+	}
+	return humanizeDuration(duration.AsDuration())
+}
+
+func humanizeDuration(duration time.Duration) string {
+	days := int64(duration.Hours() / 24)
+	hours := int64(math.Mod(duration.Hours(), 24))
+	minutes := int64(math.Mod(duration.Minutes(), 60))
+	seconds := int64(math.Mod(duration.Seconds(), 60))
+
+	chunks := []struct {
+		singularName string
+		amount       int64
+	}{
+		{"day", days},
+		{"hour", hours},
+		{"minute", minutes},
+		{"second", seconds},
+	}
+
+	var parts []string
+
+	for _, chunk := range chunks {
+		switch chunk.amount {
+		case 0:
+			continue
+		case 1:
+			parts = append(parts, fmt.Sprintf("%d %s", chunk.amount, chunk.singularName))
+		default:
+			parts = append(parts, fmt.Sprintf("%d %ss", chunk.amount, chunk.singularName))
+		}
+	}
+
+	return strings.Join(parts, " ")
+}

--- a/go/pkg/printer/string_converter.go
+++ b/go/pkg/printer/string_converter.go
@@ -1,0 +1,14 @@
+package printer
+
+import (
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type Strconv interface {
+	FormatBool(b bool) string
+
+	FormatTimestamp(dt *timestamppb.Timestamp) string
+
+	FormatDuration(dt *durationpb.Duration) string
+}

--- a/go/pkg/proto-utils/message.go
+++ b/go/pkg/proto-utils/message.go
@@ -1,0 +1,261 @@
+package proto_utils
+
+import (
+	"errors"
+	"fmt"
+	"github.com/trustero/api/go/pkg/printer"
+	"github.com/trustero/api/go/pkg/tabular"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func Tabulate(message proto.Message, strconv printer.Strconv) (attributes []string, err error) {
+	return tabulate(message.ProtoReflect(), strconv)
+}
+
+func tabulate(m protoreflect.Message, strconv printer.Strconv) (attributes []string, err error) {
+	if strconv == nil {
+		err = errors.New("string converter not set")
+		return
+	}
+	for i := 0; i < m.Descriptor().Fields().Len(); i++ {
+		fDesc, fVal := getFieldReflectionByIndex(m, i)
+		var strVal string
+		if strVal, err = printField(fDesc, fVal, strconv); err != nil {
+			return
+		}
+		attributes = append(attributes, strVal)
+	}
+
+	return
+}
+
+func isFieldListType(message protoreflect.Message, idx int) bool {
+	fd, _ := getFieldReflectionByIndex(message, idx)
+	return fd.Kind() == protoreflect.StringKind && fd.Cardinality() == protoreflect.Repeated
+}
+
+func TabulateOneOf(message proto.Message, oneOfFieldName string, strconv printer.Strconv) (result *tabular.Table, err error) {
+	oneOfValue := GetOneOfValue(message, oneOfFieldName)
+	// Assuming the first field of the wrapper class contains is a list of finding elements
+	findingElements := GetFieldAsList(oneOfValue, 0)
+
+	result = &tabular.Table{}
+	for i := 0; i < findingElements.Len(); i++ {
+		row := findingElements.Get(i).Message()
+		// Assume that, as specified by the evidence.Observations contract, the first field
+		// of each element contains the id or list of ids for instances in that can filter the element out
+		var attributes []string
+		if attributes, err = tabulateRow(row, strconv); err != nil {
+			return
+		}
+		result.Body = append(result.Body, attributes)
+	}
+	return
+}
+
+func tabulateRow(m protoreflect.Message, strconv printer.Strconv) (attributes []string, err error) {
+	if isFieldListType(m, 1) {
+		attributes, err = tabulateField(m, 1, strconv)
+		return
+	}
+
+	if attributes, err = tabulate(m, strconv); err != nil {
+		return
+	}
+	// skip the first attribute, which is the id
+	attributes = attributes[1:]
+	return
+}
+func TabulateField(message proto.Message, idx int, strconv printer.Strconv) (attributes []string, err error) {
+	return tabulateField(message.ProtoReflect(), idx, strconv)
+}
+
+func tabulateField(m protoreflect.Message, idx int, strconv printer.Strconv) (attributes []string, err error) {
+	if m.Descriptor().Oneofs().Len() > 0 {
+		onefOfDescriptor := m.Descriptor().Oneofs().Get(idx)
+		fv := m.WhichOneof(onefOfDescriptor)
+		if onefOfDescriptor != nil {
+			vd := m.Get(fv)
+			var strVal string
+			if strVal, err = printField(fv, vd, strconv); err == nil {
+				attributes = append(attributes, strVal)
+			}
+			return
+		}
+
+	}
+	fd, fv := getFieldReflectionByIndex(m, idx)
+
+	if fd.Kind() == protoreflect.StringKind && fd.Cardinality() == protoreflect.Repeated {
+		for i := 0; i < fv.List().Len(); i++ {
+			attributes = append(attributes, fv.List().Get(i).String())
+		}
+		return
+	}
+	var strVal string
+	if strVal, err = printField(fd, fv, strconv); err != nil {
+		return
+	}
+	attributes = append(attributes, strVal)
+	return
+}
+func getFieldReflectionByIndex(m protoreflect.Message, idx int) (protoreflect.FieldDescriptor, protoreflect.Value) {
+	fieldDescriptor := m.Descriptor().Fields().Get(idx)
+	fieldValue := m.Get(fieldDescriptor)
+	return fieldDescriptor, fieldValue
+}
+
+// getFieldValueAsString
+// Supported types
+//const (
+//	BoolKind     Kind = 8
+//	Int32Kind    Kind = 5
+//	Sint32Kind   Kind = 17
+//	Uint32Kind   Kind = 13
+//	Int64Kind    Kind = 3
+//	Sint64Kind   Kind = 18
+//	Uint64Kind   Kind = 4
+//	Sfixed32Kind Kind = 15
+//	Fixed32Kind  Kind = 7
+//	FloatKind    Kind = 2
+//	Sfixed64Kind Kind = 16
+//	Fixed64Kind  Kind = 6
+//	DoubleKind   Kind = 1
+//	StringKind   Kind = 9
+//)
+func printField(fd protoreflect.FieldDescriptor, fv protoreflect.Value, customStrconv printer.Strconv) (value string, err error) {
+	if customStrconv == nil {
+		err = errors.New("string converter not set")
+		return
+	}
+	switch fd.Kind() {
+	case protoreflect.BoolKind:
+		value = customStrconv.FormatBool(fv.Bool())
+		return
+	case protoreflect.EnumKind,
+		protoreflect.BytesKind,
+		protoreflect.MessageKind,
+		protoreflect.GroupKind:
+		if isTimestamp(fd) {
+			value = customStrconv.FormatTimestamp(parseTimestamp(fv))
+			return
+		}
+		if isDuration(fd) {
+			value = customStrconv.FormatDuration(parseDuration(fv))
+			return
+		}
+
+		err = errors.New("error parsing unknown value type")
+		return
+	case protoreflect.Int32Kind,
+		protoreflect.Sint32Kind,
+		protoreflect.Sfixed32Kind,
+		protoreflect.Int64Kind,
+		protoreflect.Sint64Kind,
+		protoreflect.Sfixed64Kind:
+		value = strconv.FormatInt(fv.Int(), 10)
+		return
+	case protoreflect.Uint32Kind,
+		protoreflect.Fixed32Kind,
+		protoreflect.Uint64Kind,
+		protoreflect.Fixed64Kind:
+		value = strconv.FormatUint(fv.Uint(), 10)
+		return
+	case protoreflect.FloatKind,
+		protoreflect.DoubleKind:
+		value = fmt.Sprintf("%.3f", fv.Float())
+		return
+	case protoreflect.StringKind:
+		if fd.Cardinality() == protoreflect.Repeated {
+			var items []string
+			for i := 0; i < fv.List().Len(); i++ {
+				items = append(items, fv.List().Get(i).String())
+			}
+			value = strings.Join(items, ", ")
+			return
+		}
+		value = fv.String()
+		return
+	default:
+		err = errors.New("error parsing unknown value type")
+	}
+	return
+}
+
+func parseTimestamp(fv protoreflect.Value) *timestamppb.Timestamp {
+	message := fv.Message()
+	descriptor := message.Descriptor()
+	seconds := message.Get(descriptor.Fields().Get(0)).Int()
+	nanos := int32(message.Get(descriptor.Fields().Get(1)).Int())
+	return &timestamppb.Timestamp{
+		Seconds: seconds,
+		Nanos:   nanos,
+	}
+}
+
+func parseDuration(fv protoreflect.Value) *durationpb.Duration {
+	message := fv.Message()
+	descriptor := message.Descriptor()
+	seconds := message.Get(descriptor.Fields().Get(0)).Int()
+	nanos := int32(message.Get(descriptor.Fields().Get(1)).Int())
+	return &durationpb.Duration{
+		Seconds: seconds,
+		Nanos:   nanos,
+	}
+}
+
+func isTimestamp(fd protoreflect.FieldDescriptor) bool {
+	return timestamppb.Now().ProtoReflect().Descriptor().FullName() == fd.Message().FullName()
+}
+func isDuration(fd protoreflect.FieldDescriptor) bool {
+	return durationpb.New(time.Nanosecond).ProtoReflect().Descriptor().FullName() == fd.Message().FullName()
+}
+
+func GetFieldAsList(value protoreflect.Value, fieldIndex int) protoreflect.List {
+	oneOfFieldMessageDescriptor := value.Message().Descriptor()
+	oneOfFirstFieldDescriptor := oneOfFieldMessageDescriptor.Fields().Get(fieldIndex)
+	findingElements := value.Message().Get(oneOfFirstFieldDescriptor).List()
+	return findingElements
+}
+
+// GetOneOfValue
+// Digs into a proto message where a one-of type is known to exist, and returs the value of the one-of instance in the message.
+func GetOneOfValue(protoMessage protoreflect.ProtoMessage, oneofFieldName string) protoreflect.Value {
+	findingReflectDescriptor := protoMessage.ProtoReflect().Descriptor()
+	findTypeOneOfFieldDescriptor := findingReflectDescriptor.Oneofs().ByName(protoreflect.Name(oneofFieldName)).Fields()
+	var rowsValue protoreflect.Value
+	// Loop over the OneOf of evidence.Observations and find the *one* field that is set
+	for i := 0; i < findingReflectDescriptor.Fields().Len(); i++ {
+		if protoMessage.ProtoReflect().Has(findTypeOneOfFieldDescriptor.Get(i)) {
+			rowsValue = protoMessage.ProtoReflect().Get(findTypeOneOfFieldDescriptor.Get(i))
+			break
+		}
+	}
+	return rowsValue
+}
+
+func GetId(message protoreflect.Message) (instanceIds []string, err error) {
+	// Assume that, as specified by the evidence.Observations contract, the first field
+	// of each element contains the id or list of ids for instances in that can filter the element out
+	instanceIdFieldDescriptor := message.Descriptor().Fields().Get(0)
+	instanceIdFieldValue := message.Get(instanceIdFieldDescriptor)
+
+	if instanceIdFieldDescriptor.Kind() != protoreflect.StringKind {
+		err = errors.New("expected string or repeated string in field 1 of message")
+		return
+	}
+	if instanceIdFieldDescriptor.Cardinality() == protoreflect.Repeated {
+		for k := 0; k < instanceIdFieldValue.List().Len(); k++ {
+			instanceIds = append(instanceIds, instanceIdFieldValue.List().Get(k).String())
+		}
+		return
+	}
+	instanceIds = append(instanceIds, instanceIdFieldValue.String())
+	return
+}

--- a/go/pkg/proto-utils/tr_tag.go
+++ b/go/pkg/proto-utils/tr_tag.go
@@ -1,0 +1,104 @@
+package proto_utils
+
+import (
+	"fmt"
+	reflect_utils "github.com/trustero/api/go/pkg/reflect-utils"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+type fieldTag struct {
+	IsId         bool
+	DisplayName  string
+	DisplayOrder int
+}
+
+type TrTag struct {
+	Id           string
+	DisplayName  map[string]string
+	DisplayOrder []string
+}
+
+const (
+	tagName        = "tr"
+	tfDisplayName  = "DisplayName"
+	tfDisplayOrder = "DisplayOrder"
+	tfId           = "primary_key"
+)
+
+func NewTrTag(anyVal interface{}) (tag *TrTag, err error) {
+	reflectedValue, reflectedField := reflect_utils.GetValueAndType(anyVal)
+	idIdx := -1
+	tag = &TrTag{
+		DisplayName:  make(map[string]string),
+		DisplayOrder: make([]string, reflectedField.NumField()),
+	}
+	for i := 0; i < reflectedValue.NumField(); i++ {
+		field := reflectedField.Field(i)
+		var ft *fieldTag
+		if ft, err = getFieldTag(field); err != nil || ft == nil {
+			continue
+		}
+		tag.DisplayName[field.Name] = ft.DisplayName
+		tag.DisplayOrder[ft.DisplayOrder] = field.Name
+		if ft.IsId {
+			if idIdx >= 0 {
+				err = fmt.Errorf("duplicate Id field")
+				return
+			}
+			idIdx = i
+		}
+	}
+
+	return
+}
+
+func getFieldTag(field reflect.StructField) (ft *fieldTag, err error) {
+	tagValue := field.Tag.Get(tagName)
+	if tagValue == "" {
+		return
+	}
+	ft = &fieldTag{}
+	for _, tagSection := range strings.Split(tagValue, ";") {
+		tagSection = strings.TrimSpace(tagSection)
+		if tagSection == "" {
+			continue
+		}
+		tagKeyValue := strings.Split(tagSection, ":")
+		if len(tagKeyValue) != 2 {
+			if tagSection != tfId {
+				err = fmt.Errorf("invalid tag: %s", tagSection)
+				return
+			}
+			if field.Type.Kind() != reflect.String {
+				err = fmt.Errorf("Id field must be string")
+				return
+			}
+			ft.IsId = true
+			continue
+		}
+		sectionKey := strings.TrimSpace(tagKeyValue[0])
+		sectionValue := strings.TrimSpace(tagKeyValue[1])
+		switch sectionKey {
+		case tfDisplayName:
+			ft.DisplayName = sectionValue
+		case tfDisplayOrder:
+			if ft.DisplayOrder, err = strconv.Atoi(sectionValue); err != nil || ft.DisplayOrder < 0 {
+				err = fmt.Errorf("invalid order for field %s", field.Name)
+				return
+			}
+			ft.DisplayOrder-- // cardinality starts at 1, but arrays start at 0
+		case tfId:
+			if field.Type.Kind() != reflect.String {
+				err = fmt.Errorf("Id field must be string")
+				return
+			}
+			ft.IsId = true
+		default:
+			err = fmt.Errorf("invalid tag: %s", tagSection)
+			return
+		}
+	}
+	return
+}

--- a/go/pkg/reflect-utils/utils.go
+++ b/go/pkg/reflect-utils/utils.go
@@ -1,0 +1,16 @@
+package reflect_utils
+
+import "reflect"
+
+func GetValueAndType(anyVal interface{}) (value reflect.Value, ttype reflect.Type) {
+	value = deref(reflect.ValueOf(anyVal))
+	ttype = reflect.TypeOf(anyVal).Elem()
+	return value, ttype
+}
+
+func deref(v reflect.Value) reflect.Value {
+	if v.Kind() != reflect.Ptr {
+		return v
+	}
+	return deref(v.Elem())
+}

--- a/go/pkg/tabular/markdown.go
+++ b/go/pkg/tabular/markdown.go
@@ -1,0 +1,65 @@
+package tabular
+
+import (
+	"fmt"
+	"github.com/trustero/api/go/pkg/printer"
+	"strings"
+)
+
+func NewMarkdownPrinter(table *Table) printer.Printer {
+	return &tableMarkdownPrinter{
+		table: table,
+	}
+}
+
+type tableMarkdownPrinter struct {
+	table *Table
+}
+
+func (p *tableMarkdownPrinter) Print() string {
+	if len(p.table.Headers) == 0 {
+		return ""
+	}
+
+	p.table.Prepare()
+	isColumnCenterJustified := make([]bool, len(p.table.Headers))
+	for i := range isColumnCenterJustified {
+		isColumnCenterJustified[i] = true
+	}
+	var parts = []string{
+		printRow(p.table.Headers),
+		genColumnJustification(isColumnCenterJustified),
+		printBody(p.table.Body),
+	}
+	return strings.Join(parts, "\n")
+}
+
+func printBody(body [][]string) string {
+	if len(body) == 0 {
+		return ""
+	}
+	bodyMarkdown := make([]string, len(body))
+	for i, row := range body {
+		bodyMarkdown[i] = printRow(row)
+	}
+	return strings.Join(bodyMarkdown, "\n")
+}
+
+func printRow(row []string) string {
+	return fmt.Sprintf("| %s |", strings.Join(row, " | "))
+}
+
+func genColumnJustification(isColumnCenterJustified []bool) string {
+	if len(isColumnCenterJustified) == 0 {
+		return ""
+	}
+	var columnJustification []string
+	for _, isCentered := range isColumnCenterJustified {
+		if isCentered {
+			columnJustification = append(columnJustification, ":---:")
+			continue
+		}
+		columnJustification = append(columnJustification, ":---")
+	}
+	return fmt.Sprintf("|%s|", strings.Join(columnJustification, "|"))
+}

--- a/go/pkg/tabular/markdown_test.go
+++ b/go/pkg/tabular/markdown_test.go
@@ -1,0 +1,70 @@
+package tabular_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/trustero/api/go/pkg/tabular"
+	"testing"
+)
+
+func TestEmptyTable(t *testing.T) {
+	table := &tabular.Table{
+		Headers: make([]string, 0),
+		Body:    make([][]string, 0),
+	}
+	assert.Equal(t, "", tabular.NewMarkdownPrinter(table).Print())
+}
+
+func TestOnlyOneHeaderNoBody(t *testing.T) {
+	table := &tabular.Table{
+		Headers: []string{"foo"},
+		Body:    make([][]string, 0),
+	}
+
+	expected := `| foo |
+|:---:|
+`
+	printer := tabular.NewMarkdownPrinter(table)
+	assert.Equal(t, expected, printer.Print())
+}
+func TestOnlyNHeaderNoBody(t *testing.T) {
+	table := &tabular.Table{
+		Headers: []string{"foo", "bar", "baz"},
+		Body:    make([][]string, 0),
+	}
+
+	const expected = `| foo | bar | baz |
+|:---:|:---:|:---:|
+`
+	assert.Equal(t, expected, tabular.NewMarkdownPrinter(table).Print())
+}
+
+func TestOnlyOneHeaderOneRow(t *testing.T) {
+	table := &tabular.Table{
+		Headers: []string{"foo"},
+		Body: [][]string{
+			{"foo-a"},
+		},
+	}
+	expected := `| foo |
+|:---:|
+| foo-a |`
+	assert.Equal(t, expected, tabular.NewMarkdownPrinter(table).Print())
+}
+
+func TestNHeadersNRow(t *testing.T) {
+	table := &tabular.Table{
+		Headers: []string{"foo", "bar", "baz"},
+		Body: [][]string{
+			{"foo-a", "bar-a", "baz-a"},
+			{"foo-b", "-", "-"},
+			{"foo-c", "bar-c", "-"},
+		},
+	}
+
+	expected := `| foo | bar | baz |
+|:---:|:---:|:---:|
+| foo-a | bar-a | baz-a |
+| foo-b | - | - |
+| foo-c | bar-c | - |`
+	assert.Equal(t, expected, tabular.NewMarkdownPrinter(table).Print())
+}

--- a/go/pkg/tabular/table.go
+++ b/go/pkg/tabular/table.go
@@ -1,0 +1,79 @@
+package tabular
+
+// BlankHeaderSentinel This is used as a placeholder value for when we want to insert an actual blank header value.
+var BlankHeaderSentinel = "TRUSTERO_BLANK_HEADER_SENTINEL"
+
+type Table struct {
+	Headers     []string
+	Body        [][]string
+	ProblemRows map[int]bool
+}
+
+func (t *Table) Prepare() {
+	t.annotatedTable()
+
+	t.excludeIgnored()
+}
+
+func (t *Table) excludeIgnored() {
+	ignoredIndexes := map[int]bool{}
+	j := 0
+	for i, h := range t.Headers {
+		if h == "" {
+			ignoredIndexes[i] = true
+			continue
+		} else if h == BlankHeaderSentinel {
+			t.Headers[j] = ""
+		} else {
+			t.Headers[j] = h
+		}
+		j++
+	}
+	t.Headers = t.Headers[:j]
+
+	for i, row := range t.Body {
+		j = 0
+		for k, v := range row {
+			if _, ok := ignoredIndexes[k]; ok {
+				continue
+			}
+			row[j] = v
+			j++
+		}
+		t.Body[i] = row[:j]
+	}
+}
+
+func (t *Table) annotatedTable() {
+	hasProblem := false
+	for _, hasProblem = range t.ProblemRows {
+		if hasProblem {
+			break
+		}
+	}
+	if !hasProblem {
+		return
+	}
+
+	if t.Headers != nil && len(t.Headers) > 0 {
+		// Use a known sentinel value to insert a blank header value. Otherwise, blank headers will be stripped from
+		// the markdown output.
+		t.Headers = append([]string{BlankHeaderSentinel}, t.Headers...)
+	}
+
+	for i, row := range t.Body {
+		// If there are issues, we always add a new column to the start of the row.
+		//   - If there is an issue for a row, add an icon to the new column and highlight the row.
+		//   - If there is not an issue for a row, add an empty string to the new column.
+		if t.ProblemRows[i] {
+			for j, cellContent := range row {
+				row[j] = "***" + cellContent + "***"
+			}
+			row = append([]string{"❌"}, row...)
+		} else {
+			row = append([]string{""}, row...)
+		}
+
+		(t.Body)[i] = row
+	}
+}

--- a/go/receptor_sdk/cmd/verify_test.go
+++ b/go/receptor_sdk/cmd/verify_test.go
@@ -30,6 +30,7 @@ func TestVerifyWithTestCredentials(t *testing.T) {
 	err := cmd.Verify(nil, nil)
 
 	assert.Nil(t, err)
+	mockConfig.AssertExpectations(t)
 }
 
 func TestVerify(t *testing.T) {

--- a/go/receptor_v1/struct.go
+++ b/go/receptor_v1/struct.go
@@ -1,0 +1,115 @@
+package receptor_v1
+
+import (
+	"fmt"
+	"github.com/trustero/api/go/pkg/printer"
+	. "github.com/trustero/api/go/pkg/proto-utils"
+	. "github.com/trustero/api/go/pkg/reflect-utils"
+	"github.com/trustero/api/go/pkg/tabular"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"reflect"
+	"strings"
+	"time"
+)
+
+func NewStruct(values []interface{}) (strct *Struct, err error) {
+	if len(values) == 0 {
+		return
+	}
+
+	var trTag *TrTag
+	trTag, err = NewTrTag(values[0])
+
+	strct = &Struct{
+		Rows:            make([]*Struct_Row, len(values)),
+		ColDisplayNames: trTag.DisplayName,
+		ColDisplayOrder: trTag.DisplayOrder,
+	}
+	for i, value := range values {
+		strct.Rows[i] = newStruct_Row(value, trTag)
+	}
+	return
+}
+
+func newStruct_Row(value interface{}, trTag *TrTag) (row *Struct_Row) {
+	reflectedValue, reflectedField := GetValueAndType(value)
+	row = &Struct_Row{
+		ServiceId: trTag.Id,
+		Cols:      make(map[string]*Struct_Row_Value),
+	}
+
+	for i := 0; i < reflectedValue.NumField(); i++ {
+		field := reflectedField.Field(i)
+		fieldValue := reflectedValue.Field(i)
+		switch field.Type.Kind() {
+		case reflect.String:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_StringValue{
+				StringValue: fieldValue.String(),
+			}}
+			continue
+		case reflect.Bool:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_BoolValue{
+				BoolValue: fieldValue.Bool(),
+			}}
+			continue
+		case reflect.Int32:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_Int32Value{
+				Int32Value: int32(fieldValue.Int()),
+			}}
+			continue
+		case reflect.Int, reflect.Int64:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_Int64Value{
+				Int64Value: fieldValue.Int(),
+			}}
+			continue
+		case reflect.Uint32:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_Uint32Value{
+				Uint32Value: uint32(fieldValue.Uint()),
+			}}
+			continue
+		case reflect.Uint, reflect.Uint64:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_Uint64Value{
+				Uint64Value: fieldValue.Uint(),
+			}}
+			continue
+		case reflect.Float32, reflect.Float64:
+			row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_FloatValue{
+				FloatValue: float32(fieldValue.Float()),
+			}}
+			continue
+		default:
+			if dateTime, ok := fieldValue.Interface().(time.Time); ok {
+				row.Cols[field.Name] = &Struct_Row_Value{ValueType: &Struct_Row_Value_TimestampValue{
+					TimestampValue: timestamppb.New(dateTime),
+				}}
+				continue
+			}
+		}
+		panic(fmt.Sprintf("unsupported type of field %s", field.Name))
+	}
+	return
+}
+
+// Tabulate returns the collection of elements wrapped by Struct as a 2D array, where each row is a Struct_Row and each column is an attribute.
+// The order and display names of the attributes are given by the struct's `display_order` and `display_name` fields respectively.
+func (x *Struct) Tabulate(strconv printer.Strconv) (result *tabular.Table, err error) {
+	result = &tabular.Table{}
+
+	for _, row := range x.GetRows() {
+		attributes := make([]string, len(x.GetColDisplayOrder()))
+		for i, key := range x.GetColDisplayOrder() {
+			if len(key) == 0 {
+				attributes[i] = ""
+				continue
+			}
+			var value []string
+			if value, err = TabulateField(row.GetCols()[key], 0, strconv); err != nil {
+				continue
+			}
+			attributes[i] = strings.Join(value, "")
+			result.Headers = append(result.Headers, x.GetColDisplayNames()[key])
+		}
+		result.Body = append(result.Body, attributes)
+	}
+	return
+}

--- a/go/receptor_v1/struct_test.go
+++ b/go/receptor_v1/struct_test.go
@@ -1,0 +1,111 @@
+package receptor_v1_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/trustero/api/go/pkg/printer"
+	"github.com/trustero/api/go/receptor_v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
+)
+
+type Foo struct {
+	Id   string    `tr:"primary_key"`
+	Name string    `tr:"DisplayName:Name Of Foo;DisplayOrder:2"`
+	Date time.Time `tr:"DisplayName:Created on;DisplayOrder:1"`
+}
+
+func TestNewStruct(t *testing.T) {
+	timestamp := int64(1658575538938)
+	data := []interface{}{
+		&Foo{
+			Id:   "123",
+			Name: "Foo",
+			Date: time.UnixMilli(timestamp),
+		},
+	}
+
+	newStruct, err := receptor_v1.NewStruct(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, newStruct)
+	assert.NotNil(t, newStruct.GetRows())
+	assert.NotNil(t, newStruct.GetRows())
+	assert.NotNil(t, newStruct.GetColDisplayOrder())
+	assert.NotNil(t, newStruct.GetColDisplayNames())
+}
+
+func TestNewEvidence(t *testing.T) {
+	timestamp := int64(1658575538938)
+	data := []interface{}{
+		&Foo{
+			Id:   "123",
+			Name: "Foo",
+			Date: time.UnixMilli(timestamp),
+		},
+	}
+
+	newStruct, err := receptor_v1.NewStruct(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, newStruct)
+	assert.NotNil(t, newStruct.GetRows())
+	assert.NotNil(t, newStruct.GetColDisplayOrder())
+	assert.NotNil(t, newStruct.GetColDisplayNames())
+
+	assert.Len(t, newStruct.GetColDisplayNames(), 3)
+	assert.Equal(t, newStruct.GetColDisplayNames()["Date"], "Created on")
+	assert.Equal(t, newStruct.GetColDisplayNames()["Name"], "Name Of Foo")
+}
+
+func TestTableFromMapFinding(t *testing.T) {
+	data := make(map[string]*receptor_v1.Struct_Row_Value)
+	data["hello"] = &receptor_v1.Struct_Row_Value{ValueType: &receptor_v1.Struct_Row_Value_StringValue{
+		StringValue: "world",
+	}}
+	timestamp := int64(1658575538938)
+	data["foo"] = &receptor_v1.Struct_Row_Value{
+		ValueType: &receptor_v1.Struct_Row_Value_TimestampValue{
+			TimestampValue: timestamppb.New(time.UnixMilli(timestamp)),
+		},
+	}
+	mapFindings := []*receptor_v1.Struct_Row{
+		{
+			ServiceId: "123",
+			Cols:      data,
+		},
+	}
+	testStruct := &receptor_v1.Struct{
+		Rows: mapFindings,
+		ColDisplayNames: map[string]string{
+			"hello": "Name",
+			"foo":   "Date",
+		},
+		ColDisplayOrder: []string{"foo", "hello"},
+	}
+
+	table, err := testStruct.Tabulate(printer.SimpleStrconv)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(table.Body))
+	assert.Equal(t, "2022-Jul-23", table.Body[0][0])
+	assert.Equal(t, "world", table.Body[0][1])
+}
+
+type TestData struct {
+	id    string    `tr:"primary_key"`
+	hello string    `tr:"DisplayName:Name;DisplayOrder:2"`
+	Foo   time.Time `tr:"DisplayName:Date;DisplayOrder:1"`
+}
+
+func TestTableFromAny(t *testing.T) {
+	testDate := &TestData{
+		id:    "123",
+		hello: "world",
+		Foo:   time.UnixMilli(int64(1658575538938)),
+	}
+	testStruct, _ := receptor_v1.NewStruct([]interface{}{testDate})
+
+	table, err := testStruct.Tabulate(printer.SimpleStrconv)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(table.Body))
+	assert.Equal(t, "2022-Jul-23", table.Body[0][0])
+	assert.Equal(t, "world", table.Body[0][1])
+}


### PR DESCRIPTION
AP-3713: Bring over proto-markdown utils

We wish to provide markdown capabilities for our proto types. To avoid dependencies to 
private repos, the markdown utitlites have been extracted and will now be imported from the 
api repo

