### PR TITLE
Add 'descriptor' subcommand to print credentials descriptor for scope ui.  Let receptor author use field tags to describe credential fields.  Cleaned up subcommand flags.

### DIFF
--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"encoding/json"
 	"strconv"
 	"time"
 
@@ -29,9 +28,10 @@ const (
 	memberEntity = "Member"
 )
 
+// Credential object
 type Receptor struct {
-	Token   string
-	GroupID string
+	Token   string `trustero:"display:GitLab Access Token;placeholder:token"`
+	GroupID string `trustero:"display:GitLab Group ID;placeholder:group id"`
 }
 
 func (r *Receptor) GetReceptorType() string {
@@ -42,9 +42,8 @@ func (r *Receptor) GetKnownServices() []string {
 	return []string{serviceName}
 }
 
-func (r *Receptor) UnmarshalCredentials(credentials string) (obj interface{}, err error) {
-	obj, err = receptor_sdk.UnmarshalCredentials(credentials, r)
-	return
+func (r *Receptor) GetCredentialObj() (credentialObj interface{}) {
+	return r
 }
 
 func (r *Receptor) Verify(credentials interface{}) (ok bool, err error) {
@@ -123,22 +122,5 @@ func newGitLabUser(user *gitlab.User, group *gitlab.Group) *GitLabUser {
 }
 
 func main() {
-	receptor := &Receptor{}
-
-	// Add convenience token
-	cmd.RootCmd.PersistentFlags().StringVarP(&receptor.Token, "token", "t", "", "GitLab user access token")
-	cmd.RootCmd.PersistentFlags().StringVarP(&receptor.GroupID, "gid", "g", "", "GitLab group id")
-
-	// Get credentials from flags
-	receptor_sdk.CredentialsFromFlags = func() string {
-		if len(receptor.Token) > 0 {
-			b, err := json.Marshal(receptor)
-			if err == nil {
-				return string(b)
-			}
-		}
-		return ""
-	}
-
 	cmd.Execute(&Receptor{})
 }

--- a/go/receptor_sdk/cmd/descriptor.go
+++ b/go/receptor_sdk/cmd/descriptor.go
@@ -1,0 +1,89 @@
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	descUse   = "descriptor"
+	descShort = "Print credentials descriptor for Trustero internal use"
+)
+
+type desc struct {
+	cmd *cobra.Command
+}
+
+func (d *desc) getCommand() *cobra.Command {
+	return d.cmd
+}
+
+func (d *desc) setup() {
+	d.cmd = &cobra.Command{
+		Use:   descUse,
+		Short: descShort,
+		Args:  cobra.MinimumNArgs(0),
+		RunE:  descriptor,
+	}
+}
+
+// Cobra executes this function on descriptor command.
+func descriptor(_ *cobra.Command, args []string) (err error) {
+	var desc string
+	if desc, err = toDescriptor(receptorImpl.GetCredentialObj()); err == nil {
+		fmt.Println(desc)
+	}
+	return
+}
+
+type credential struct {
+	Display     string `json:"display"`
+	Placeholder string `json:"placeholder"`
+	Field       string `json:"field"`
+}
+
+type credentials struct {
+	Credentials []*credential `json:"credentials"`
+}
+
+func toDescriptor(credentialObj interface{}) (descriptor string, err error) {
+	vt := reflect.Indirect(reflect.ValueOf(credentialObj)).Type()
+
+	creds := &credentials{}
+	for i := 0; i < vt.NumField(); i++ {
+		tags := expandFieldTag(vt.Field(i))
+		fname := vt.Field(i).Name
+		display := getTagField(tags, displayField, fname)
+		creds.Credentials = append(creds.Credentials, &credential{
+			Display:     display,
+			Field:       fname,
+			Placeholder: getTagField(tags, placeholderField, strings.ToLower(fname)),
+		})
+	}
+
+	var bytes []byte
+	if bytes, err = json.MarshalIndent(creds, "", "  "); err == nil {
+		descriptor = string(bytes)
+	}
+	return
+}
+
+func addCredentialFlags(credentialObj interface{}) (err error) {
+	v := reflect.Indirect(reflect.ValueOf(credentialObj))
+	vt := v.Type()
+	for i := 0; i < vt.NumField(); i++ {
+		tags := expandFieldTag(vt.Field(i))
+		fname := vt.Field(i).Name
+		display := getTagField(tags, displayField, fname)
+		sptr := (*string)(reflect.Indirect(v.Field(i)).Addr().UnsafePointer())
+		AddStrFlag("verify", sptr, strings.ToLower(fname), "", "", display)
+		AddStrFlag("scan", sptr, strings.ToLower(fname), "", "", display)
+	}
+	return
+}

--- a/go/receptor_sdk/cmd/fieldtag.go
+++ b/go/receptor_sdk/cmd/fieldtag.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	tagName      = "trustero"
-	idField      = "id"
-	displayField = "display"
-	orderField   = "order"
+	tagName          = "trustero"
+	idField          = "id"
+	displayField     = "display"
+	orderField       = "order"
+	placeholderField = "placeholder"
 )
 
 func expandFieldTag(field reflect.StructField) (tags map[string]string) {
@@ -55,4 +56,11 @@ func getKVPair(str string) (k, v string) {
 		v = ""
 	}
 	return
+}
+
+func getTagField(tags map[string]string, fieldName, fieldDefault string) string {
+	if display, ok := tags[fieldName]; ok {
+		return display
+	}
+	return fieldDefault
 }

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -4,7 +4,7 @@ package cmd
 
 import (
 	"encoding/base64"
-	"errors"
+	"encoding/json"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -18,102 +18,130 @@ import (
 	receptor "github.com/trustero/api/go/receptor_v1"
 )
 
+var rootCmd command
 var cfgFile string                     // Configuration file as an alternative to command line flags
 var serviceProviderAccount string      // Receptor's configured service provider account
 var receptorImpl receptor_sdk.Receptor // Receptor implementation
 
-// RootCmd is the base command when called without any subcommands such as 'scan' or 'verify'.
-// The RoodCmd command does nothing when invoked without a subcommand.
-var RootCmd = &cobra.Command{
-	Use:   "", // Set to this receptor's type
-	Short: "Run a receptor in one of 2 modes: verify or scan.",
-	Long: `
+const (
+	rootShortDesc = "Run a receptor in one of 2 modes: verify or scan."
+	rootLongDesc  = `
 Run a receptor in one of 2 modes: verify or scan.  The verify mode checks the
 validity of the given service provider account credential.  The scan mode either
 discovers services enabled in the service provider account or reports the service
 provider account's service configurations.  In the latter case, scan is invoked
-with the --find-evidence flag.`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// If the first argument is 'dryrun' then do not report the command
-		// results to Trustero.  Instead, display the results to console.
-		if len(args) > 0 && args[0] != "dryrun" {
-			client.InitGRPCClient(receptor_sdk.Cert, receptor_sdk.CertServerOverride)
-		} else {
-			receptor_sdk.NoSave = true
-		}
-	},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		if client.ServerConn != nil {
-			if err := client.ServerConn.CloseClient(); err != nil {
-				log.Error().Msg(err.Error())
-			}
-		}
-	},
+with the --find-evidence flag.`
+)
+
+// Setup sub commands
+var cmds = map[string]command{
+	"verify":     &verifi{},
+	"scan":       &scann{},
+	"services":   &svcs{},
+	"descriptor": &desc{},
 }
 
 // Execute the command
 func Execute(r receptor_sdk.Receptor) {
-	receptorImpl = r
-	receptor_sdk.ModelID = receptorImpl.GetReceptorType()
-	RootCmd.Use = receptor_sdk.ModelID
-	cobra.CheckErr(RootCmd.Execute())
-}
-
-// Setup verify and scan subcommands.
-var commands = []*cobra.Command{
-	verifyCmd,
-	scanCmd,
-	servicesCmd,
-}
-
-func init() {
 	cobra.OnInitialize(initConfig)
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file, defaults to $HOME/.receptor.yaml")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.Host, "host", "s", "localhost", "Trustero GRPC API endpoint host name")
-	RootCmd.PersistentFlags().IntVarP(&receptor_sdk.Port, "port", "p", 8888, "Trustero GRPC API endpoint port number")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.Cert, "cert", "c", "dev", "Server cert ca to use - dev or prod")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.CertServerOverride, "certoverride", "o", "dev.ntrce.co", "Server cert ca server override")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.LogLevel, "level", "l", "error", "trace, debug, info, warn, error, fatal, or panic")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.LogFile, "log-file", "", "", "Log file path")
-	RootCmd.PersistentFlags().StringVarP(&receptor_sdk.ReceptorId, "receptor-id", "r", "", "Trustero receptor configuration identifier")
+	// initialize cobra commands
+	rootCmd = &root{}
+	rootCmd.setup()
+	for _, c := range cmds {
+		c.setup()
+		rootCmd.getCommand().AddCommand(c.getCommand())
+	}
 
-	if err := viper.BindPFlag("host", RootCmd.PersistentFlags().Lookup("host")); err != nil {
-		log.Error().Msg(err.Error())
-		return
-	}
-	if err := viper.BindPFlag("port", RootCmd.PersistentFlags().Lookup("port")); err != nil {
-		log.Error().Msg(err.Error())
-		return
-	}
-	if err := viper.BindPFlag("cert", RootCmd.PersistentFlags().Lookup("cert")); err != nil {
-		log.Error().Msg(err.Error())
-		return
-	}
-	if err := viper.BindPFlag("certoverride", RootCmd.PersistentFlags().Lookup("certoverride")); err != nil {
-		log.Error().Msg(err.Error())
-		return
-	}
-	if err := viper.BindPFlag("level", RootCmd.PersistentFlags().Lookup("level")); err != nil {
-		log.Error().Msg(err.Error())
-		return
-	}
-	viper.SetDefault("host", "localhost")
-	viper.SetDefault("port", 8888)
-	viper.SetDefault("cert", "dev")
-	viper.SetDefault("certoverride", "localhost")
-	viper.SetDefault("level", "error")
+	receptorImpl = r
+	receptor_sdk.ModelID = receptorImpl.GetReceptorType()
+	rootCmd.getCommand().Use = receptor_sdk.ModelID
+	_ = addCredentialFlags(r.GetCredentialObj())
+	cobra.CheckErr(rootCmd.getCommand().Execute())
+}
 
-	for _, cmd := range commands {
-		addReceptorFlags(cmd)
-		RootCmd.AddCommand(cmd)
+type command interface {
+	getCommand() *cobra.Command
+	setup()
+}
+
+type root struct {
+	cmd *cobra.Command
+}
+
+func (r *root) getCommand() *cobra.Command {
+	return r.cmd
+}
+
+func (r *root) setup() {
+	r.cmd = &cobra.Command{
+		Short: rootShortDesc,
+		Long:  rootLongDesc,
+	}
+	addStrFlag(r.cmd, &cfgFile, "config", "", "", "Config file, defaults to $HOME/.receptor.yaml")
+	addStrFlag(r.cmd, &receptor_sdk.LogLevel, "level", "l", "error", "trace, debug, info, warn, error, fatal, or panic")
+	addStrFlag(r.cmd, &receptor_sdk.LogFile, "log-file", "", "", "Log file path")
+}
+
+func addGrpcFlags(cmd *cobra.Command) {
+	addStrFlag(cmd, &receptor_sdk.Host, "host", "s", "localhost", "Trustero GRPC API endpoint host name")
+	addIntFlag(cmd, &receptor_sdk.Port, "port", "p", 8888, "Trustero GRPC API endpoint port number")
+	addStrFlag(cmd, &receptor_sdk.Cert, "cert", "c", "dev", "Server cert ca to use - dev or prod")
+	addStrFlag(cmd, &receptor_sdk.CertServerOverride, "certoverride", "o", "dev.ntrce.co", "Server cert ca server override")
+	addStrFlag(cmd, &receptor_sdk.ReceptorId, "receptor-id", "r", "", "Trustero receptor configuration identifier")
+	addBoolFlag(cmd, &receptor_sdk.NoSave, "nosave", "n", false, "Send results to console instead of Trustero")
+	addStrFlag(cmd, &receptor_sdk.Notify, "notify", "", "", "Notify Trustero with Tracer ID on command completion")
+	addStrFlag(cmd, &receptor_sdk.CredentialsBase64URL, "credentials", "", "", "Base64 URL encoded service provider credential")
+}
+
+func AddStrFlag(cmd string, p *string, name, shorthand, value, usage string) {
+	if c, ok := cmds[cmd]; ok && c != nil {
+		addStrFlag(c.getCommand(), p, name, shorthand, value, usage)
 	}
 }
 
-func addReceptorFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVarP(&receptor_sdk.NoSave, "nosave", "n", false, "Send results to console instead of Trustero")
-	cmd.PersistentFlags().StringVarP(&receptor_sdk.Notify, "notify", "", "", "Notify Trustero with Tracer ID on command completion")
-	cmd.PersistentFlags().StringVarP(&receptor_sdk.CredentialsBase64URL, "credentials", "", "", "Base64 URL encoded service provider credential")
+func addStrFlag(cmd *cobra.Command, p *string, name, shorthand, value, usage string) {
+	addFlag(cmd, name, value, func() {
+		cmd.PersistentFlags().StringVarP(p, name, shorthand, value, usage)
+	})
+}
+
+func addIntFlag(cmd *cobra.Command, p *int, name, shorthand string, value int, usage string) {
+	addFlag(cmd, name, value, func() {
+		cmd.PersistentFlags().IntVarP(p, name, shorthand, value, usage)
+	})
+}
+
+func addBoolFlag(cmd *cobra.Command, p *bool, name, shorthand string, value bool, usage string) {
+	addFlag(cmd, name, value, func() {
+		cmd.PersistentFlags().BoolVarP(p, name, shorthand, value, usage)
+	})
+}
+
+func addFlag(cmd *cobra.Command, name string, value interface{}, addFlag func()) {
+	if f := cmd.PersistentFlags().Lookup(name); f == nil {
+		addFlag()
+		_ = viper.BindPFlag(name, f)
+		viper.SetDefault(name, value)
+	}
+}
+
+func grpcPreRun(_ *cobra.Command, args []string) {
+	// If the first argument is 'dryrun' then do not report the command
+	// results to Trustero.  Instead, display the results to console.
+	if len(args) > 0 && args[0] != "dryrun" {
+		client.InitGRPCClient(receptor_sdk.Cert, receptor_sdk.CertServerOverride)
+	} else {
+		receptor_sdk.NoSave = true
+	}
+}
+
+func grpcPostRun(_ *cobra.Command, _ []string) {
+	if client.ServerConn != nil {
+		if err := client.ServerConn.CloseClient(); err != nil {
+			log.Error().Msg(err.Error())
+		}
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -163,11 +191,11 @@ func invokeWithContext(token string, run commandInContext) (err error) {
 		return
 	}
 
-	// Get service provider account credentialStr from CLI
+	// Get service provider account credentialStr from --credentials CLI flag
 	credentialStr, err = getCredentialStringFromCLI()
 
 	// If credentialStr not provided on CLI, get it from Trustero server
-	if err != nil || len(credentialStr) == 0 {
+	if !receptor_sdk.NoSave && len(credentialStr) == 0 {
 		// Get service provider account credentialStr and config from Trustero.
 		var receptorInfo *receptor.ReceptorConfiguration
 		if receptorInfo, err = getReceptorConfig(rc); err != nil {
@@ -177,8 +205,14 @@ func invokeWithContext(token string, run commandInContext) (err error) {
 		serviceProviderAccount = receptorInfo.ServiceProviderAccount
 	}
 
-	// Unmarshal credential
-	credentialObj, err = receptorImpl.UnmarshalCredentials(credentialStr)
+	// Unmarshal json string credential
+	if len(credentialStr) > 0 {
+		credentialObj, err = unmarshalCredentials(credentialStr, receptorImpl.GetCredentialObj())
+	} else {
+		// If there is no credential json string provided, assume the credentials are set through
+		// credential-specific CLI flags
+		credentialObj = receptorImpl.GetCredentialObj()
+	}
 
 	// Invoke receptor's method
 	if err == nil {
@@ -192,11 +226,11 @@ func getReceptorClient(token string) (rc receptor.ReceptorClient, err error) {
 		// Mock client
 		rc = &MockReceptorClient{}
 	} else {
-		// Connect to Trustero
+		// Connect to Trustero grpc server
 		if err = client.ServerConn.Dial(token, receptor_sdk.Host, receptor_sdk.Port); err != nil {
 			return
 		}
-		// Get client
+		// Get grpc client
 		rc = client.ServerConn.GetReceptorClient()
 	}
 	return
@@ -224,7 +258,7 @@ func notify(rc receptor.ReceptorClient, command, result string, e error) (err er
 }
 
 func getCredentialStringFromCLI() (credentials string, err error) {
-	// Extract credentials from CLI flags
+	// Extract credentials from --credentials CLI flag
 	if len(receptor_sdk.CredentialsBase64URL) > 0 {
 		// Get credentials from the --credentials flag
 		var creds []byte
@@ -232,14 +266,13 @@ func getCredentialStringFromCLI() (credentials string, err error) {
 			return
 		}
 		credentials = string(creds)
-	} else {
-		// Construct credentials from custom CLI flags.
-		credentials = receptor_sdk.CredentialsFromFlags()
 	}
 
-	if len(credentials) == 0 {
-		err = errors.New("no credentials provided")
-	}
+	return
+}
 
+func unmarshalCredentials(credentials string, credentialsObj interface{}) (obj interface{}, err error) {
+	err = json.Unmarshal([]byte(credentials), credentialsObj)
+	obj = credentialsObj
 	return
 }

--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -11,22 +11,37 @@ import (
 	"github.com/trustero/api/go/receptor_v1"
 )
 
-// Set up the 'scan' CLI subcommand.
-var scanCmd = &cobra.Command{
-	Use:   "scan <trustero_access_token>|dryrun",
-	Short: "Scan for services or evidence in a service provider account.",
-	Long: `
+const (
+	scanUse   = "scan <trustero_access_token>|dryrun"
+	scanShort = "Scan for services or evidence in a service provider account"
+	scanLong  = `
 Scan for services and evidences in-use in a service provider account.  Scan
 command decodes the base64 URL encoded credentials from the '--credentials'
 command line flag and check it's validity.  If 'dryrun' is specified instead
 of a Trustero access token, the scan command will not report the results to
-Trustero and instead print the results to console.`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: scan,
+Trustero and instead print the results to console.`
+)
+
+type scann struct {
+	cmd *cobra.Command
 }
 
-func init() {
-	scanCmd.PersistentFlags().BoolVarP(&receptor_sdk.FindEvidence, "find-evidence", "", false,
+func (s *scann) getCommand() *cobra.Command {
+	return s.cmd
+}
+
+func (s *scann) setup() {
+	s.cmd = &cobra.Command{
+		Use:     scanUse,
+		Short:   scanShort,
+		Long:    scanLong,
+		Args:    cobra.MinimumNArgs(1),
+		PreRun:  grpcPreRun,
+		RunE:    scan,
+		PostRun: grpcPostRun,
+	}
+	addGrpcFlags(s.cmd)
+	addBoolFlag(s.cmd, &receptor_sdk.FindEvidence, "find-evidence", "", false,
 		"Scan for evidences in a service provider account")
 }
 

--- a/go/receptor_sdk/cmd/services.go
+++ b/go/receptor_sdk/cmd/services.go
@@ -8,12 +8,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Set up the 'services' CLI subcommand.
-var servicesCmd = &cobra.Command{
-	Use:   "services",
-	Short: "Show list of service names this receptor will collect evidence for.",
-	Args:  cobra.MinimumNArgs(0),
-	RunE:  services,
+const (
+	svcsUse   = "services"
+	svcsShort = "Show list of service names this receptor will collect evidence for"
+)
+
+type svcs struct {
+	cmd *cobra.Command
+}
+
+func (s *svcs) getCommand() *cobra.Command {
+	return s.cmd
+}
+
+func (s *svcs) setup() {
+	s.cmd = &cobra.Command{
+		Use:   svcsUse,
+		Short: svcsShort,
+		Args:  cobra.MinimumNArgs(0),
+		RunE:  services,
+	}
 }
 
 // Cobra executes this function on services command.

--- a/go/receptor_sdk/cmd/verify.go
+++ b/go/receptor_sdk/cmd/verify.go
@@ -10,18 +10,36 @@ import (
 	"github.com/trustero/api/go/receptor_v1"
 )
 
-// Set up the 'verify' CLI subcommand.
-var verifyCmd = &cobra.Command{
-	Use:   "verify <trustero_access_token>|dryrun",
-	Short: "Verify read-only access to a service provider account.",
-	Long: `
+const (
+	verifyUse   = "verify <trustero_access_token>|dryrun"
+	verifyShort = "Verify read-only access to a service provider account"
+	verifyLong  = `
 Verify read-only access to a service provider account.  Verify command
 decodes the base64 URL encoded credentials from the '--credentials' command
 line flag and check it's validity.  If 'dryrun' is specified instead of a
 Trustero access token, the verify command will not report the results to
-Trustero and instead print the results to console.`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: verify,
+Trustero and instead print the results to console.`
+)
+
+type verifi struct {
+	cmd *cobra.Command
+}
+
+func (v *verifi) getCommand() *cobra.Command {
+	return v.cmd
+}
+
+func (v *verifi) setup() {
+	v.cmd = &cobra.Command{
+		Use:     verifyUse,
+		Short:   verifyShort,
+		Long:    verifyLong,
+		Args:    cobra.MinimumNArgs(1),
+		PreRun:  grpcPreRun,
+		RunE:    verify,
+		PostRun: grpcPostRun,
+	}
+	addGrpcFlags(v.cmd)
 }
 
 // Cobra executes this function on verify command.


### PR DESCRIPTION
# Summary

Add 'descriptor' subcommand to print credentials descriptor for scope ui.  Let receptor author use field tags to describe credential 
fields.  Cleaned up subcommand flags.

This pr changes the receptor sdk's contract and will break trr-gitlab.  However, an updated gitlab receptor can be found in 
go/example/gitlab_receptor.  New gitlab_receptor command line example (notice the change to token and group id flag names):

./build/gitlab_receptor scan dryrun --token glpat-o5qF62hCSLky3S-qo9Ly --groupid 56215073 --find-evidence

# Test Plan

ran gitlab_receptor

# Task
[AP-###]
