### PR TITLE
Fix documentation so it adheres to https://go.dev/doc/comment standards.

### DIFF
--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -1,5 +1,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
+// Package main is an example of how to use the Receptor SDK to build a Receptor CLI
 package main
 
 import (
@@ -12,6 +14,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
+// GitLabUser represents a type of evidence to emit to Trustero as part of a finding.
 type GitLabUser struct {
 	Username         string     `trustero:"id:;display:Username;order:1"`
 	Name             string     `trustero:"display:Name;order:2"`
@@ -22,30 +25,35 @@ type GitLabUser struct {
 	LastActivityOn   *time.Time `trustero:"display:Last Activity On;order:7"`
 }
 
+// Receptor defines the GitLab service credentials required for connecting to the GitLab
+// service and gathering necessary evidence to support its use.
+type Receptor struct {
+	Token   string `trustero:"display:GitLab Access Token;placeholder:token"`
+	GroupID string `trustero:"display:GitLab Group ID;placeholder:group id"`
+}
+
 const (
 	serviceName  = "GitLab"
 	groupEntity  = "Group"
 	memberEntity = "Member"
 )
 
-// Credential object
-type Receptor struct {
-	Token   string `trustero:"display:GitLab Access Token;placeholder:token"`
-	GroupID string `trustero:"display:GitLab Group ID;placeholder:group id"`
-}
-
+// GetReceptorType implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) GetReceptorType() string {
 	return "gitlab_receptor"
 }
 
+// GetKnownServices implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) GetKnownServices() []string {
 	return []string{serviceName}
 }
 
+// GetCredentialObj implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) GetCredentialObj() (credentialObj interface{}) {
 	return r
 }
 
+// Verify implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) Verify(credentials interface{}) (ok bool, err error) {
 	c := credentials.(*Receptor)
 	ok = true
@@ -59,6 +67,7 @@ func (r *Receptor) Verify(credentials interface{}) (ok bool, err error) {
 	return
 }
 
+// Discover implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) Discover(credentials interface{}) (svcs []*receptor_v1.ServiceEntity, err error) {
 	c := credentials.(*Receptor)
 	var git *gitlab.Client
@@ -73,6 +82,7 @@ func (r *Receptor) Discover(credentials interface{}) (svcs []*receptor_v1.Servic
 	return services.Entities, err
 }
 
+// Report implements the [receptor_sdk.Receptor] interface.
 func (r *Receptor) Report(credentials interface{}) (evidences []*receptor_sdk.Evidence, err error) {
 	c := credentials.(*Receptor)
 	report := receptor_sdk.NewReport()

--- a/go/receptor_sdk/client/apiclient.go
+++ b/go/receptor_sdk/client/apiclient.go
@@ -1,8 +1,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
-package client
 
-// Create common setup and teardown for dependent services
+// Package client provides GRPC utilities to simplify connecting to Trustero GRPC service.
+package client
 
 import (
 	"context"
@@ -28,17 +28,18 @@ type ServerConnection struct {
 	TlsDialOption grpc.DialOption
 }
 
+// InitGRPCClient sets up the SSL certificate for subsequent Trustero GRPC connections.
 func InitGRPCClient(cert, override string) {
 	ServerConn = &ServerConnection{}
 
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
-		log.Err(err).Msg("error loading system cert pool")
+		log.Err(err).Msg("error loading system certificate pool")
 		rootCAs = x509.NewCertPool()
 	}
 
 	if cert == "dev" {
-		log.Info().Msgf("using dev cert with server name override %s", override)
+		log.Info().Msgf("using a development SSL certificate with server name override %s", override)
 		if !rootCAs.AppendCertsFromPEM([]byte(config.DevCertCa)) {
 			panic("Error parsing X.509 certificate CA.")
 		}
@@ -51,6 +52,7 @@ func InitGRPCClient(cert, override string) {
 		}))
 }
 
+// Dial makes a GRPC connection to Trustero GRPC service.  A Trustero JWT bearer token must be provided.
 func (sc *ServerConnection) Dial(token, host string, port int) (err error) {
 	// Dial options
 	grpcCred := oauth.NewOauthAccess(&oauth2.Token{AccessToken: token})
@@ -67,6 +69,7 @@ func (sc *ServerConnection) Dial(token, host string, port int) (err error) {
 	return
 }
 
+// CloseClient closes a previously dialed Trustero GRPC connection.
 func (sc *ServerConnection) CloseClient() error {
 	if sc.Connection != nil {
 		return sc.Connection.Close()
@@ -74,6 +77,7 @@ func (sc *ServerConnection) CloseClient() error {
 	return nil
 }
 
+// GetReceptorClient returns a Go client instance that implements the [receptor_v1.Receptor] Protobuf interface.
 func (sc *ServerConnection) GetReceptorClient() (rc receptor_v1.ReceptorClient) {
 	rc = receptor_v1.NewReceptorClient(sc.Connection)
 	return

--- a/go/receptor_sdk/client/random.go
+++ b/go/receptor_sdk/client/random.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package client
 
 import (
@@ -17,6 +18,7 @@ const (
 
 var src = rand.NewSource(time.Now().UnixNano())
 
+// RandString returns a random string of length n.
 func RandString(n int) string {
 	b := make([]byte, n)
 	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!

--- a/go/receptor_sdk/cmd/descriptor.go
+++ b/go/receptor_sdk/cmd/descriptor.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/discover.go
+++ b/go/receptor_sdk/cmd/discover.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/fieldtag.go
+++ b/go/receptor_sdk/cmd/fieldtag.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/log.go
+++ b/go/receptor_sdk/cmd/log.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/mock_receptor.go
+++ b/go/receptor_sdk/cmd/mock_receptor.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/report.go
+++ b/go/receptor_sdk/cmd/report.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/services.go
+++ b/go/receptor_sdk/cmd/services.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/cmd/verify.go
+++ b/go/receptor_sdk/cmd/verify.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package cmd
 
 import (

--- a/go/receptor_sdk/config/cert.go
+++ b/go/receptor_sdk/config/cert.go
@@ -1,8 +1,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package config
 
-// Certificate CA for dev
+// Certificate CA for Trustero developer GRPC server instance.
 var DevCertCa = `-----BEGIN CERTIFICATE-----
 MIIDdDCCAlwCCQC25Z0Mbc8rDTANBgkqhkiG9w0BAQsFADB8MQswCQYDVQQGEwJV
 UzELMAkGA1UECAwCQ0ExEjAQBgNVBAcMCVBhbG8gQWx0bzEYMBYGA1UECgwPSW50

--- a/go/receptor_sdk/receptor.go
+++ b/go/receptor_sdk/receptor.go
@@ -1,5 +1,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
+// Package receptor_sdk is simple platform that simplifies the development of a Trustero Receptor
+// CLI that emit evidence finding to Trustero.  A Receptor CLI has a standard set of command
+// line arguments and flags to support interacting with the Trustero server.
 package receptor_sdk
 
 import (
@@ -36,10 +40,9 @@ type Receptor interface {
 	// GetCredentialObj returns an instance of a credential struct used for service provider authentication.  The
 	// credential struct contains only public string fields with Go struct field tags:
 	//
-	//  Field tag name is 'trustero' with sub-tags separated by ';'
-	//  Valid sub-tags: display, placeholder
-	//    display provides the human-readable name of the field
-	//    placeholder provides a default field value suggestion for the field
+	// Field tag name is 'trustero' with sub-tags separated by ';' and valid sub-tags are 'display', and 'placeholder'
+	//  - display provides the human-readable name of the field
+	//  - placeholder provides a default field value suggestion for the field
 	//
 	// For example:
 	//
@@ -66,12 +69,11 @@ type Receptor interface {
 // Golang struct.  Fields of this evidence row struct must be public and annotated with Trustero's field annotation
 // where:
 //
-//	Field tag name is 'trustero' with sub-tags separated by ';'
-//	Valid sub-tags: 'id', 'display', and 'order'
-//	   id specifies the field is unique identifier for the struct.
-//	   display provides the human-readable name for the field.
-//	   order is an integer number starting with 1, denoting the order in which the field should be displayed in a
-//	   table.
+// Field tag name is 'trustero' with sub-tags separated by ';' and valid sub-tags are 'id', 'display', and 'order'
+//   - id specifies the field is unique identifier for the struct.
+//   - display provides the human-readable name for the field.
+//   - order is an integer number starting with 1, denoting the order in which the field should be displayed in a
+//     table.
 //
 // For example:
 //

--- a/go/receptor_sdk/reporter.go
+++ b/go/receptor_sdk/reporter.go
@@ -1,5 +1,6 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
 package receptor_sdk
 
 import (

--- a/go/receptor_v1/receptor.pb.go
+++ b/go/receptor_v1/receptor.pb.go
@@ -122,7 +122,6 @@ type Evidence struct {
 	ServiceName string `protobuf:"bytes,3,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
 	// Entity_type specifies the row type and should correspond to a ServiceEntity.  An entity_type typically
 	// represents a specific configurable entity such as AWS ECS "Cluster".
-	// @required
 	EntityType string `protobuf:"bytes,4,opt,name=entity_type,json=entityType,proto3" json:"entity_type,omitempty"`
 	// Sources are raw service provider API requests and responses used to generate this evidence.  The raw API requests
 	// and responses serve as proof the evidence correlates to real service configurations.
@@ -306,12 +305,10 @@ type Document struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Mime is the document type defined using MIME.
-	// (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
-	// @required
+	// Mime is the document type defined using [MIME].
+	// [MIME]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 	Mime string `protobuf:"bytes,2,opt,name=mime,proto3" json:"mime,omitempty"`
 	// Body is the opaque document body.  The document body must match the type defined by the mime attribute.
-	// @required
 	Body []byte `protobuf:"bytes,3,opt,name=body,proto3" json:"body,omitempty"`
 }
 
@@ -372,15 +369,12 @@ type Struct struct {
 
 	// Rows of key-value pairs.  Each row typically represents the configuration of a service instance or an data
 	// type such as a member of GitLab group.
-	// @required
 	Rows []*Row `protobuf:"bytes,2,rep,name=rows,proto3" json:"rows,omitempty"`
 	// Col_display_names is a map of row column name to it's corresponding display name.  Display names are used
 	// by the user interface to render a field in a struct's rows.
-	// @required
 	ColDisplayNames map[string]string `protobuf:"bytes,3,rep,name=col_display_names,json=colDisplayNames,proto3" json:"col_display_names,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Col_display_order is an ordered list of row column names.  The order of the column names are used by the user
 	// interface to render the column order of a struct's rows.
-	// @required
 	ColDisplayOrder []string `protobuf:"bytes,4,rep,name=col_display_order,json=colDisplayOrder,proto3" json:"col_display_order,omitempty"`
 }
 
@@ -449,7 +443,6 @@ type Row struct {
 	// Cols are columns of the row in column name to value pairs.  All rows in a struct must have the same column
 	// names and corresponding value types.  In addition, one of the key-value pair in the cols map must be the
 	// entity_instance_id, a unique instance of this row's Struct.entity_type.
-	// @required
 	Cols map[string]*Value `protobuf:"bytes,2,rep,name=cols,proto3" json:"cols,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -499,8 +492,7 @@ func (x *Row) GetCols() map[string]*Value {
 	return nil
 }
 
-// Value is a Struct.Row's column value.  Value types can be simple protobuf scalar or google.proto.Timestamp.
-// @required
+// Value is a [Struct.row.col] column value.  Value types can be simple protobuf scalar or [google.proto.Timestamp].
 type Value struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -692,13 +684,10 @@ type ServiceEntities struct {
 	// Receptor_type is a unique receptor type.  A stable string identifier that represent the type of receptor
 	// reporting this finding.  The identifier is a simple URL encode string that includes the organization name
 	// and a service provider name.  For example "trustero_gitlab".
-	// @required
 	ReceptorType string `protobuf:"bytes,1,opt,name=receptor_type,json=receptorType,proto3" json:"receptor_type,omitempty"`
 	// Service_provider_account is the service provider account where the services are configured in.
-	// @required
 	ServiceProviderAccount string `protobuf:"bytes,2,opt,name=service_provider_account,json=serviceProviderAccount,proto3" json:"service_provider_account,omitempty"`
 	// Entities is a list of service instances configured in the service provider account.
-	// @required
 	Entities []*ServiceEntity `protobuf:"bytes,3,rep,name=entities,proto3" json:"entities,omitempty"`
 }
 
@@ -766,22 +755,18 @@ type ServiceEntity struct {
 
 	// Service_name of the entity source.  This is a Trustero assigned identifier for a known service such as
 	// "GitLab" or AWS "ECS".
-	// @required
 	ServiceName string `protobuf:"bytes,1,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
 	// Entity_type is a service configurable object type such as a GitLab "repository" or AWS ECS "cluster".  The
 	// entity_instance_name and entity_instance_id must represent an instance of the subtype.  For example,
 	// "Java 1.5" maybe a valid GitLab repository name or "Elastic front end cluster" maybe a valid AWS ECS
 	// cluster name.
-	// @required
 	EntityType string `protobuf:"bytes,2,opt,name=entity_type,json=entityType,proto3" json:"entity_type,omitempty"`
 	// Entity_instance_name of a discovered service entity instance.  For example, an AWS ECS cluster name or a
 	// GitLab repository name.  Entity_instance_name of an entity may change for a given entity instance but
 	// it's entity_instance_id is stable.
-	// @required
 	EntityInstanceName string `protobuf:"bytes,3,opt,name=entity_instance_name,json=entityInstanceName,proto3" json:"entity_instance_name,omitempty"`
 	// Entity_instance_id of a discovered entity instance.  For example, an AWS ECS cluster UUID or GitLab
 	// repository ID.
-	// @required
 	EntityInstanceId string `protobuf:"bytes,4,opt,name=entity_instance_id,json=entityInstanceId,proto3" json:"entity_instance_id,omitempty"`
 }
 

--- a/go/receptor_v1/tabulator.go
+++ b/go/receptor_v1/tabulator.go
@@ -1,5 +1,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
+
+// Package receptor_v1 provides the Go GRPC client bindings to communicate with the Trustero service.
 package receptor_v1
 
 import (


### PR DESCRIPTION
# Summary

Fix documentation to adhere to https://go.dev/doc/comment.  Also added an extra line after license headers to all .go and .proto files to 
prevent 'go doc' from thinking it's package documentation.

# Test Plan

make and run gitlab_receptor and observed output.
ran 'go doc' on all packages and verified documentation formating.

# Task
[AP-###]
