### PR TITLE
[AP-3713] Add receptor type to Descriptor call

### DIFF
--- a/go/receptor_sdk/cmd/descriptor.go
+++ b/go/receptor_sdk/cmd/descriptor.go
@@ -93,6 +93,9 @@ func addCredentialFlags(credentialObj interface{}) (err error) {
 	return
 }
 
+// This func cleans up the the receptor type,
+// a receptor type can only include letters, numbers, "-", and "_"
+// all other characters will be converted to "_"
 func GetParsedReceptorType() (parsedName string) {
 	receptorName := receptorImpl.GetReceptorType()
 	regex, _ := regexp.Compile(`[^-a-z0-9A-Z_]`)

--- a/go/receptor_sdk/cmd/descriptor.go
+++ b/go/receptor_sdk/cmd/descriptor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -50,7 +51,8 @@ type credential struct {
 }
 
 type credentials struct {
-	Credentials []*credential `json:"credentials"`
+	Credentials  []*credential `json:"credentials"`
+	ReceptorType string        `json:"receptorType"`
 }
 
 func toDescriptor(credentialObj interface{}) (descriptor string, err error) {
@@ -67,6 +69,8 @@ func toDescriptor(credentialObj interface{}) (descriptor string, err error) {
 			Placeholder: getTagField(tags, placeholderField, strings.ToLower(fname)),
 		})
 	}
+
+	creds.ReceptorType = GetParsedReceptorType()
 
 	var bytes []byte
 	if bytes, err = json.MarshalIndent(creds, "", "  "); err == nil {
@@ -87,4 +91,11 @@ func addCredentialFlags(credentialObj interface{}) (err error) {
 		addStrFlagP("scan", sptr, strings.ToLower(fname), "", "", display)
 	}
 	return
+}
+
+func GetParsedReceptorType() (parsedName string) {
+	receptorName := receptorImpl.GetReceptorType()
+	regex, _ := regexp.Compile(`[^-a-z0-9A-Z_]`)
+	res := regex.ReplaceAll([]byte(receptorName), []byte("_"))
+	return string(res)
 }

--- a/go/receptor_sdk/cmd/discover.go
+++ b/go/receptor_sdk/cmd/discover.go
@@ -19,7 +19,7 @@ func discover(rc receptor_v1.ReceptorClient, credentials interface{}) (err error
 
 	// Report discovered services to Trustero
 	var services receptor_v1.ServiceEntities
-	services.ReceptorType = receptorImpl.GetReceptorType()
+	services.ReceptorType = GetParsedReceptorType()
 	services.ServiceProviderAccount = serviceProviderAccount
 	services.Entities = discovered
 

--- a/go/receptor_sdk/cmd/report.go
+++ b/go/receptor_sdk/cmd/report.go
@@ -33,7 +33,7 @@ func report(rc receptor_v1.ReceptorClient, credentials interface{}) (err error) 
 		return
 	}
 
-	finding.ReceptorType = receptorImpl.GetReceptorType()
+	finding.ReceptorType = GetParsedReceptorType()
 	finding.ServiceProviderAccount = serviceProviderAccount
 
 	// Convert and append discovered evidences to reported evidences

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -59,7 +59,7 @@ func Execute(r receptor_sdk.Receptor) {
 	}
 
 	receptorImpl = r
-	receptor_sdk.ModelID = receptorImpl.GetReceptorType()
+	receptor_sdk.ModelID = GetParsedReceptorType()
 	rootCmd.getCommand().Use = receptor_sdk.ModelID
 	_ = addCredentialFlags(r.GetCredentialObj())
 	cobra.CheckErr(rootCmd.getCommand().Execute())


### PR DESCRIPTION
# Summary

The receptor needs a way to communicate what type it is
this can be done in the descriptor call.

The Descriptor call to a receptor returns the type of credentials that a 
receptor needs, as well as the type of the receptor

This will be used when we add an outsourced receptor to our product

# Test Plan

run a descriptor call on the example receptor, make sure the receptory type
is included in the output

# Task
[AP-3713]


[AP-3713]: https://intersticelabs.atlassian.net/browse/AP-3713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ