### PR TITLE
Ignore unknown flags

### DIFF
--- a/go/receptor_sdk/cmd/descriptor.go
+++ b/go/receptor_sdk/cmd/descriptor.go
@@ -28,11 +28,13 @@ func (d *desc) getCommand() *cobra.Command {
 
 func (d *desc) setup() {
 	d.cmd = &cobra.Command{
-		Use:   descUse,
-		Short: descShort,
-		Args:  cobra.MinimumNArgs(0),
-		RunE:  descriptor,
+		Use:          descUse,
+		Short:        descShort,
+		Args:         cobra.MinimumNArgs(0),
+		RunE:         descriptor,
+		SilenceUsage: true,
 	}
+	d.cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 // Cobra executes this function on descriptor command.
@@ -93,9 +95,8 @@ func addCredentialFlags(credentialObj interface{}) (err error) {
 	return
 }
 
-// This func cleans up the the receptor type,
-// a receptor type can only include letters, numbers, "-", and "_"
-// all other characters will be converted to "_"
+// GetParsedReceptorType returns a normalized receptor type string.  A receptor type string only includes letters,
+// numbers, "-", and "_".  All other characters will be converted to "_".
 func GetParsedReceptorType() (parsedName string) {
 	receptorName := receptorImpl.GetReceptorType()
 	regex, _ := regexp.Compile(`[^-a-z0-9A-Z_]`)

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -80,9 +80,12 @@ func (r *root) getCommand() *cobra.Command {
 
 func (r *root) setup() {
 	r.cmd = &cobra.Command{
-		Short: rootShortDesc,
-		Long:  rootLongDesc,
+		Short:        rootShortDesc,
+		Long:         rootLongDesc,
+		SilenceUsage: true,
 	}
+	r.cmd.FParseErrWhitelist.UnknownFlags = true
+
 	addStrFlag(r.cmd, &cfgFile, "config", "", "", "Config file, defaults to $HOME/.receptor.yaml")
 	addStrFlag(r.cmd, &receptor_sdk.LogLevel, "level", "l", "error", "trace, debug, info, warn, error, fatal, or panic")
 	addStrFlag(r.cmd, &receptor_sdk.LogFile, "log-file", "", "", "Log file path")
@@ -228,6 +231,7 @@ func invokeWithContext(token string, run commandInContext) (err error) {
 	if err != nil {
 		log.Error().Err(err)
 	}
+
 	return
 }
 

--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -33,14 +33,16 @@ func (s *scann) getCommand() *cobra.Command {
 
 func (s *scann) setup() {
 	s.cmd = &cobra.Command{
-		Use:     scanUse,
-		Short:   scanShort,
-		Long:    scanLong,
-		Args:    cobra.MinimumNArgs(1),
-		PreRun:  grpcPreRun,
-		RunE:    scan,
-		PostRun: grpcPostRun,
+		Use:          scanUse,
+		Short:        scanShort,
+		Long:         scanLong,
+		Args:         cobra.MinimumNArgs(1),
+		PreRun:       grpcPreRun,
+		RunE:         scan,
+		PostRun:      grpcPostRun,
+		SilenceUsage: true,
 	}
+	s.cmd.FParseErrWhitelist.UnknownFlags = true
 	addGrpcFlags(s.cmd)
 	addBoolFlag(s.cmd, &receptor_sdk.FindEvidence, "find-evidence", "", false,
 		"Scan for evidences in a service provider account")

--- a/go/receptor_sdk/cmd/services.go
+++ b/go/receptor_sdk/cmd/services.go
@@ -24,11 +24,13 @@ func (s *svcs) getCommand() *cobra.Command {
 
 func (s *svcs) setup() {
 	s.cmd = &cobra.Command{
-		Use:   svcsUse,
-		Short: svcsShort,
-		Args:  cobra.MinimumNArgs(0),
-		RunE:  services,
+		Use:          svcsUse,
+		Short:        svcsShort,
+		Args:         cobra.MinimumNArgs(0),
+		RunE:         services,
+		SilenceUsage: true,
 	}
+	s.cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 // Cobra executes this function on services command.

--- a/go/receptor_sdk/cmd/verify.go
+++ b/go/receptor_sdk/cmd/verify.go
@@ -32,14 +32,17 @@ func (v *verifi) getCommand() *cobra.Command {
 
 func (v *verifi) setup() {
 	v.cmd = &cobra.Command{
-		Use:     verifyUse,
-		Short:   verifyShort,
-		Long:    verifyLong,
-		Args:    cobra.MinimumNArgs(1),
-		PreRun:  grpcPreRun,
-		RunE:    verify,
-		PostRun: grpcPostRun,
+		Use:          verifyUse,
+		Short:        verifyShort,
+		Long:         verifyLong,
+		Args:         cobra.MinimumNArgs(1),
+		PreRun:       grpcPreRun,
+		RunE:         verify,
+		PostRun:      grpcPostRun,
+		SilenceUsage: true,
 	}
+	v.cmd.FParseErrWhitelist.UnknownFlags = true
+
 	addGrpcFlags(v.cmd)
 }
 


### PR DESCRIPTION
# Summary

Ignore unknown flags.

# Test Plan

make and run github receptor and observed that given the unknown '--exclude' flag, the command 
continues to execute.

# Task
[AP-###]
