### PR TITLE
retrieve Service Provider when credential string is supplied

### DIFF
--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -203,13 +203,15 @@ func invokeWithContext(token string, run commandInContext) (err error) {
 	credentialStr, err = getCredentialStringFromCLI()
 
 	// If credentialStr not provided on CLI, get it from Trustero server
-	if !receptor_sdk.NoSave && len(credentialStr) == 0 {
+	if !receptor_sdk.NoSave {
 		// Get service provider account credentialStr and config from Trustero.
 		var receptorInfo *receptor.ReceptorConfiguration
 		if receptorInfo, err = getReceptorConfig(rc); err != nil {
 			return err
 		}
-		credentialStr = receptorInfo.GetCredential()
+		if len(credentialStr) == 0 {
+			credentialStr = receptorInfo.GetCredential()
+		}
 		serviceProviderAccount = receptorInfo.ServiceProviderAccount
 	}
 


### PR DESCRIPTION
# Summary

A way to set to retrieve the service provider data when the credentials are set from command line
# Test Plan

Ran against some current receptors.
