### PR TITLE
[AP-007] don't render columns without a display order

### DIFF
--- a/go/receptor_v1/tabulator.go
+++ b/go/receptor_v1/tabulator.go
@@ -52,12 +52,6 @@ func (s *Struct) getHeaderKeys() (displayHeaders []string) {
 	}
 
 	displayHeaders = s.ColDisplayOrder
-	for _, h := range allHeaders {
-		// If displayHeader doesn't contain a known column key, add the column key
-		if !contains(s.ColDisplayOrder, h) {
-			displayHeaders = append(displayHeaders, h)
-		}
-	}
 
 	return
 }


### PR DESCRIPTION
# Summary:

We don't want to render all fields automatically -- only those that have
`order` defined in the struct tags.
