### PR TITLE
[AP-4234] modify AddService to allow empty strings

### DIFF
--- a/go/receptor_sdk/reporter.go
+++ b/go/receptor_sdk/reporter.go
@@ -89,7 +89,9 @@ func NewServiceEntities() *ServiceEntities {
 
 // AddService adds a services to discovered services
 func (s *ServiceEntities) AddService(typeName, typeId, instanceName, instanceId string) *ServiceEntities {
-	s.Entities = append(s.Entities, newService(typeName, typeId, instanceName, instanceId))
+	if len(typeName) > 0 {
+		s.Entities = append(s.Entities, newService(typeName, typeId, instanceName, instanceId))
+	}
 	return s
 }
 

--- a/go/receptor_sdk/reporter.go
+++ b/go/receptor_sdk/reporter.go
@@ -89,9 +89,7 @@ func NewServiceEntities() *ServiceEntities {
 
 // AddService adds a services to discovered services
 func (s *ServiceEntities) AddService(typeName, typeId, instanceName, instanceId string) *ServiceEntities {
-	if len(typeName) > 0 && len(typeId) > 0 && len(instanceName) > 0 && len(instanceId) > 0 {
-		s.Entities = append(s.Entities, newService(typeName, typeId, instanceName, instanceId))
-	}
+	s.Entities = append(s.Entities, newService(typeName, typeId, instanceName, instanceId))
 	return s
 }
 


### PR DESCRIPTION
# Summary
Modify AddService to allow empty strings in the typeid, instance name and instance id categories for receptors that don't have services.

# Test Plan
It ran 
# Task
[AP-4234]


[AP-4234]: https://intersticelabs.atlassian.net/browse/AP-4234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ