### PR TITLE
[AP-007] added it so time before the epoch in seconds were also set to -

### DIFF
--- a/go/receptor_v1/tabulator.go
+++ b/go/receptor_v1/tabulator.go
@@ -89,7 +89,7 @@ func toStringValue(value *Value) (str string) {
 
 	} else if t, ok := v.(*Value_TimestampValue); ok {
 		dt := t.TimestampValue
-		if dt == nil || (dt.Nanos == 0 && dt.Seconds == 0) {
+		if dt == nil || (dt.Nanos == 0 && dt.Seconds <= 0) {
 			str = "-"
 		} else {
 			str = dt.AsTime().Format(dateTimeLayout)


### PR DESCRIPTION
# Summary

Null json dates end up being converted to large negative integers when received via receptor,  change it that every date before time 0 is turned in to "-"
# Test Plan
Hope
# Task
[AP-007]
