### PR TITLE
[AP-4723] New evidenceinfo command

### DIFF
--- a/go/receptor_sdk/cmd/evidenceinfo.go
+++ b/go/receptor_sdk/cmd/evidenceinfo.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	eviUse   = "evidenceinfo"
+	eviShort = "Print evidence caption and description"
+)
+
+type evi struct {
+	cmd *cobra.Command
+}
+
+func (e *evi) getCommand() *cobra.Command {
+	return e.cmd
+}
+
+func (e *evi) setup() {
+	e.cmd = &cobra.Command{
+		Use:          eviUse,
+		Short:        eviShort,
+		Args:         cobra.MinimumNArgs(0),
+		RunE:         printEvidenceInfo,
+		SilenceUsage: true,
+	}
+	e.cmd.FParseErrWhitelist.UnknownFlags = true
+}
+
+// Cobra executes this function on descriptor command.
+func printEvidenceInfo(_ *cobra.Command, args []string) (err error) {
+	for _, e := range receptorImpl.GetEvidenceInfo() {
+		println(e.Caption)
+		println(e.Description)
+	}
+	return
+}

--- a/go/receptor_sdk/cmd/evidenceinfo.go
+++ b/go/receptor_sdk/cmd/evidenceinfo.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"github.com/spf13/cobra"
 )
 
@@ -28,11 +29,20 @@ func (e *evi) setup() {
 	e.cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
-// Cobra executes this function on descriptor command.
+type EvidenceInfo struct {
+	Caption     string `json:"caption"`
+	Description string `json:"description"`
+}
+
+// Cobra executes this function on evidenceinfo command.
 func printEvidenceInfo(_ *cobra.Command, args []string) (err error) {
 	for _, e := range receptorImpl.GetEvidenceInfo() {
-		println(e.Caption)
-		println(e.Description)
+		evidenceInfo := EvidenceInfo{
+			Caption:     e.Caption,
+			Description: e.Description,
+		}
+		evS, _ := json.MarshalIndent(evidenceInfo, "", "    ")
+		println(evS)
 	}
 	return
 }

--- a/go/receptor_sdk/cmd/evidenceinfo.go
+++ b/go/receptor_sdk/cmd/evidenceinfo.go
@@ -42,7 +42,7 @@ func printEvidenceInfo(_ *cobra.Command, args []string) (err error) {
 			Description: e.Description,
 		}
 		evS, _ := json.MarshalIndent(evidenceInfo, "", "    ")
-		println(evS)
+		println(string(evS))
 	}
 	return
 }

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -43,6 +43,7 @@ var cmds = map[string]command{
 	"scan":       &scann{},
 	"services":   &svcs{},
 	"descriptor": &desc{},
+	"evidences":  &evi{},
 }
 
 // Execute is the entry point into the CLI framework.  Receptor author implements the [receptor_sdk.Receptor]

--- a/go/receptor_sdk/receptor.go
+++ b/go/receptor_sdk/receptor.go
@@ -52,6 +52,7 @@ type Receptor interface {
 	//  }
 	GetCredentialObj() (credentialObj interface{})
 
+	GetEvidenceInfo() (evidences []*Evidence)
 	// Verify read-only access to a service provider account.  Return ok if the credentials are valid and err
 	// if any error is encountered in contacting the service provider.  This method is invoked from the following
 	// ClI:  <receptor_type> verify

--- a/go/receptor_sdk/receptor.go
+++ b/go/receptor_sdk/receptor.go
@@ -52,7 +52,11 @@ type Receptor interface {
 	//  }
 	GetCredentialObj() (credentialObj interface{})
 
+	//GetEvidenceInfo returns a list of Evidences that a receptor has implemented
+	//The metadata is extracted and then printed out
+	//<receptor_type> evidenceinfo
 	GetEvidenceInfo() (evidences []*Evidence)
+
 	// Verify read-only access to a service provider account.  Return ok if the credentials are valid and err
 	// if any error is encountered in contacting the service provider.  This method is invoked from the following
 	// ClI:  <receptor_type> verify


### PR DESCRIPTION
# Summary

Modified the interface for receptor_sdk to require GetEvidenceInfo and implemented the flags to run an evidence info command printing out the data extracted


# Test Plan
Runs on command line

# Task
[AP-4723]
