### PR TITLE
[AP-4992] remove double discover scans

### DIFF
--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -74,11 +74,6 @@ func scan(_ *cobra.Command, args []string) (err error) {
 			// Let Trustero know the credentials have been verified.
 			_, err = rc.Verified(context.Background(), toVerifyResult(ok, err))
 
-			// Discover services in-use in the service provider account
-			if err = discover(rc, credentials); err != nil {
-				return
-			}
-
 			// Report evidence discovered in the service provider account
 			if receptor_sdk.FindEvidence {
 				err = report(rc, credentials)

--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -82,6 +82,11 @@ func scan(_ *cobra.Command, args []string) (err error) {
 			// Report evidence discovered in the service provider account
 			if receptor_sdk.FindEvidence {
 				err = report(rc, credentials)
+			} else {
+				// Discover services in-use in the service provider account only run if --find-evidence is not run since discover runs in report
+				if err = discover(rc, credentials); err != nil {
+					return
+				}
 			}
 
 			return


### PR DESCRIPTION
# Summary
When finding evidence it runs discover scans twice, only do it once.
# Test Plan

Run locally 
# Task
[AP-4992]


[AP-4992]: https://intersticelabs.atlassian.net/browse/AP-4992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ