### PR TITLE
[AP-8148][AP-8139] SDK support Create logo and instructions from receptors

### DIFF
--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -83,6 +83,14 @@ func (r *Receptor) GetConfigObj() (config interface{}) {
 	return nil
 }
 
+func (r *Receptor) GetAuthMethods() interface{} {
+	return receptorPackage.GetAuthMethodImpl()
+}
+
+func (r *Receptor) GetConfigObjDesc() interface{} {
+	return receptorPackage.GetConfigObjDescImpl()
+}
+
 func main() {
 	cmd.Execute(&Receptor{})
 }

--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -91,6 +91,15 @@ func (r *Receptor) GetConfigObjDesc() interface{} {
 	return receptorPackage.GetConfigObjDescImpl()
 }
 
+func (r *Receptor) GetLogo() (string, error) {
+	logo, _ := receptorPackage.GetLogoImpl()
+	return logo, nil
+}
+func (r *Receptor) GetInstructions() (string, error) {
+	logo, _ := receptorPackage.GetInstructionsImpl()
+	return logo, nil
+}
+
 func main() {
 	cmd.Execute(&Receptor{})
 }

--- a/go/examples/gitlab_receptor/receptorPackage/receptorPackage.go
+++ b/go/examples/gitlab_receptor/receptorPackage/receptorPackage.go
@@ -81,3 +81,11 @@ func ReportImpl(token string, groupId string) (evidences []*receptor_sdk.Evidenc
 func ConfigureImpl(token string, groupId string) (config *receptor_v1.ReceptorConfiguration, err error) {
 	return nil, nil
 }
+
+func GetAuthMethodImpl() interface{} {
+	return nil
+}
+
+func GetConfigObjDescImpl() interface{} {
+	return nil
+}

--- a/go/examples/gitlab_receptor/receptorPackage/receptorPackage.go
+++ b/go/examples/gitlab_receptor/receptorPackage/receptorPackage.go
@@ -89,3 +89,11 @@ func GetAuthMethodImpl() interface{} {
 func GetConfigObjDescImpl() interface{} {
 	return nil
 }
+
+func GetLogoImpl() (string, error) {
+	return "", nil
+}
+
+func GetInstructionsImpl() (string, error) {
+	return "", nil
+}

--- a/go/receptor_sdk/cmd/instructions.go
+++ b/go/receptor_sdk/cmd/instructions.go
@@ -31,7 +31,7 @@ func (l *instruct) setup() {
 	l.cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
-// Cobra executes this function on logo command.
+// Cobra executes this function on instructions command.
 func instructions(_ *cobra.Command, args []string) (err error) {
 	if instructions, err := receptorImpl.GetInstructions(); err == nil {
 		println(instructions)

--- a/go/receptor_sdk/cmd/instructions.go
+++ b/go/receptor_sdk/cmd/instructions.go
@@ -8,33 +8,33 @@ import (
 )
 
 const (
-	logoUse   = "logo"
-	logoShort = "Dump logo Trustero internal use"
+	instructionsUse   = "instructions"
+	instructionsShort = "Dump instructions Trustero internal use"
 )
 
-type logor struct {
+type instruct struct {
 	cmd *cobra.Command
 }
 
-func (l *logor) getCommand() *cobra.Command {
+func (l *instruct) getCommand() *cobra.Command {
 	return l.cmd
 }
 
-func (l *logor) setup() {
+func (l *instruct) setup() {
 	l.cmd = &cobra.Command{
 		Use:          logoUse,
 		Short:        logoShort,
 		Args:         cobra.MinimumNArgs(0),
-		RunE:         logo,
+		RunE:         instructions,
 		SilenceUsage: true,
 	}
 	l.cmd.FParseErrWhitelist.UnknownFlags = true
 }
 
 // Cobra executes this function on logo command.
-func logo(_ *cobra.Command, args []string) (err error) {
-	if logo, err := receptorImpl.GetLogo(); err == nil {
-		println(logo)
+func instructions(_ *cobra.Command, args []string) (err error) {
+	if instructions, err := receptorImpl.GetInstructions(); err == nil {
+		println(instructions)
 	}
 	return
 }

--- a/go/receptor_sdk/cmd/instructions.go
+++ b/go/receptor_sdk/cmd/instructions.go
@@ -22,8 +22,8 @@ func (l *instruct) getCommand() *cobra.Command {
 
 func (l *instruct) setup() {
 	l.cmd = &cobra.Command{
-		Use:          logoUse,
-		Short:        logoShort,
+		Use:          instructionsUse,
+		Short:        instructionsShort,
 		Args:         cobra.MinimumNArgs(0),
 		RunE:         instructions,
 		SilenceUsage: true,

--- a/go/receptor_sdk/cmd/logo.go
+++ b/go/receptor_sdk/cmd/logo.go
@@ -1,0 +1,64 @@
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+package cmd
+
+import (
+	// "encoding/json"
+	// "fmt"
+	// "reflect"
+	// "regexp"
+	// "strings"
+
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	logoUse   = "logo"
+	logoShort = "Dump logo Trustero internal use"
+)
+
+type getlogo struct {
+	cmd *cobra.Command
+}
+
+func (l *getlogo) getCommand() *cobra.Command {
+	return l.cmd
+}
+
+func (l *getlogo) setup() {
+	l.cmd = &cobra.Command{
+		Use:          logoUse,
+		Short:        logoShort,
+		Args:         cobra.MinimumNArgs(0),
+		RunE:         logo,
+		SilenceUsage: true,
+	}
+	l.cmd.FParseErrWhitelist.UnknownFlags = true
+}
+
+// Cobra executes this function on logo command.
+func logo(_ *cobra.Command, args []string) (err error) {
+	svg, err := readSVGFile("logo.svg")
+	println(svg)
+	return
+}
+
+func readSVGFile(filePath string) (svgContent string, err error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return
+	}
+
+	// Return the contents as a string
+	return string(data), nil
+}

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -39,12 +39,13 @@ with the --find-evidence flag.`
 
 // Setup sub commands
 var cmds = map[string]command{
-	"verify":     &verifi{},
-	"scan":       &scann{},
-	"services":   &svcs{},
-	"descriptor": &desc{},
-	"evidences":  &evi{},
-	"logo":       &getlogo{},
+	"verify":       &verifi{},
+	"scan":         &scann{},
+	"services":     &svcs{},
+	"descriptor":   &desc{},
+	"evidences":    &evi{},
+	"logo":         &logor{},
+	"instructions": &instruct{},
 }
 
 // Execute is the entry point into the CLI framework.  Receptor author implements the [receptor_sdk.Receptor]

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -44,6 +44,7 @@ var cmds = map[string]command{
 	"services":   &svcs{},
 	"descriptor": &desc{},
 	"evidences":  &evi{},
+	"logo":       &getlogo{},
 }
 
 // Execute is the entry point into the CLI framework.  Receptor author implements the [receptor_sdk.Receptor]

--- a/go/receptor_sdk/receptor.go
+++ b/go/receptor_sdk/receptor.go
@@ -86,7 +86,18 @@ type Receptor interface {
 	// CLI: <receptor_type> scan --find-evidence
 	Report(credentials interface{}, config interface{}) (evidences []*Evidence, err error)
 
+	// Configure returns a ReceptorConfiguration object that represents the configuration of the receptor
+	// Configure is used when there special configurations required for the receptor that the user can set
+	// This method is invoked from the following CLI: <receptor_type> configure
 	Configure(credentials interface{}) (config *receptor_v1.ReceptorConfiguration, err error)
+
+	// GetLogo returns the content of the logo in svg format for the receptor
+	// This method is invoked from the following CLI: <receptor_type> logo
+	GetLogo() (logo string, err error)
+
+	// GetInstructions returns the instructions in markdown format for settings up the providers during receptor activation
+	// This method is invoked from the following CLI: <receptor_type> instructions
+	GetInstructions() (instructions string, err error)
 }
 
 // Evidence is a discovered evidence from an in-use service.  All rows in the evidence are instances of the same


### PR DESCRIPTION
# Summary

This PR adds necessary support for receptors using the sdk to enable logo and instructions commands.

# Test Plan

Tested receptors with logo and instructions commands

# Task
[AP-8139]
[AP-8148]


[AP-8139]: https://intersticelabs.atlassian.net/browse/AP-8139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AP-8148]: https://intersticelabs.atlassian.net/browse/AP-8148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ