### PR TITLE
[AP-9152]API Support for Authenticated "evidenceinfo"

### DIFF
--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -68,7 +68,7 @@ func (r *Receptor) Report(credentials interface{}, config interface{}) (evidence
 
 // GetEvidenceInfo returns a list of all the possible evidence created. The return value should not have any actual
 // rows or source data, just the Caption and Description
-func (r *Receptor) GetEvidenceInfo() (evidences []*receptor_sdk.Evidence) {
+func (r *Receptor) GetEvidenceInfo(credentials interface{}) (evidences []*receptor_sdk.Evidence) {
 	return
 }
 

--- a/go/receptor_sdk/cmd/instructions.go
+++ b/go/receptor_sdk/cmd/instructions.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func (l *instruct) setup() {
 // Cobra executes this function on instructions command.
 func instructions(_ *cobra.Command, args []string) (err error) {
 	if instructions, err := receptorImpl.GetInstructions(); err == nil {
-		println(instructions)
+		fmt.Println(instructions)
 	}
 	return
 }

--- a/go/receptor_sdk/cmd/root.go
+++ b/go/receptor_sdk/cmd/root.go
@@ -43,7 +43,7 @@ var cmds = map[string]command{
 	"scan":         &scann{},
 	"services":     &svcs{},
 	"descriptor":   &desc{},
-	"evidences":    &evi{},
+	"evidenceinfo": &evi{},
 	"logo":         &logor{},
 	"instructions": &instruct{},
 }

--- a/go/receptor_sdk/receptor.go
+++ b/go/receptor_sdk/receptor.go
@@ -73,7 +73,7 @@ type Receptor interface {
 	//GetEvidenceInfo returns a list of Evidences that a receptor has implemented
 	//The metadata is extracted and then printed out
 	//<receptor_type> evidenceinfo
-	GetEvidenceInfo() (evidences []*Evidence)
+	GetEvidenceInfo(credentials interface{}) (evidences []*Evidence)
 
 	// Verify read-only access to a service provider account.  Return ok if the credentials are valid and err
 	// if any error is encountered in contacting the service provider.  This method is invoked from the following


### PR DESCRIPTION
# Summary

This PR adds authenticated "evidenceinfo" to receptor commands. With GRC platforms we do not know the structure of the evidence at compile time. This will be computed by the receptor during runtime when necessary credentials are supplied with  evidenceinfo command. 
ex : `<path_to_receptor_executable>/<receptor_executable> evidenceinfo --credentials \{base64_url_encoded_credential}`
# Test Plan

Tested locally with  a receptor.

# Task
[AP-9152]


[AP-9152]: https://intersticelabs.atlassian.net/browse/AP-9152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ