### PR TITLE
[AP-9949]Fix duplicate evidence report inside batch

### DIFF
--- a/go/examples/gitlab_receptor/main.go
+++ b/go/examples/gitlab_receptor/main.go
@@ -67,7 +67,7 @@ func (r *Receptor) Report(credentials interface{}, config interface{}) (evidence
 }
 
 func (r *Receptor) ReportBatch(credentials interface{}, evidenceChan chan []*receptor_sdk.Evidence) {
-	return
+	close(evidenceChan)
 }
 
 // GetEvidenceInfo returns a list of all the possible evidence created. The return value should not have any actual

--- a/go/receptor_sdk/cmd/report.go
+++ b/go/receptor_sdk/cmd/report.go
@@ -51,6 +51,7 @@ func report(rc receptor_v1.ReceptorClient, credentials interface{}, config inter
 		if err != nil {
 			log.Err(err).Msg("failed to report evidence")
 			// Continue on to next batch even after an error
+			finding.Evidences = []*receptor_v1.Evidence{} // Empty every time for new evidence
 			continue
 		}
 		finding.Evidences = []*receptor_v1.Evidence{} // Empty every time for new evidence
@@ -159,10 +160,10 @@ func reportEvidence(rc receptor_v1.ReceptorClient, finding *receptor_v1.Finding,
 			// Append to Finding
 			finding.Evidences = append(finding.Evidences, &reportEvidence)
 		}
-
-		// Report evidence findings to Trustero
-		_, err = rc.Report(context.Background(), finding)
 	}
+	_, err = rc.Report(context.Background(), finding)
+	finding.Evidences = []*receptor_v1.Evidence{} // Empty every time for new evidence
+
 	return
 
 }


### PR DESCRIPTION

# Summary

close channel for unmplemented batch report

fix duplicating evidence report inside a batch

# Test Plan

Attached receptor in batch mode to test

# Task
[AP-9949]


[AP-9949]: https://intersticelabs.atlassian.net/browse/AP-9949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ