### PR TITLE
[AP-12575]Bug-Receptor SDK not reporting Config changes in Scan mode

### DIFF
--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -79,6 +80,19 @@ func scan(_ *cobra.Command, args []string) (err error) {
 			if !ok {
 				return
 			}
+			//Send the config back to Trustero if there is additional config
+			if config != nil {
+				jsonBytes, err := json.Marshal(receptorImpl.GetConfigObj())
+				if err != nil {
+					return err
+				}
+				_, err = rc.SetConfiguration(context.Background(), &receptor_v1.ReceptorConfiguration{
+					ReceptorObjectId: receptor_sdk.ReceptorId,
+					Config:           string(jsonBytes),
+					ModelId:          receptorImpl.GetReceptorType(),
+				})
+			}
+			
 			// Report evidence discovered in the service provider account
 			if receptor_sdk.FindEvidence {
 				err = report(rc, credentials, config)

--- a/go/receptor_sdk/cmd/scan.go
+++ b/go/receptor_sdk/cmd/scan.go
@@ -92,7 +92,7 @@ func scan(_ *cobra.Command, args []string) (err error) {
 					ModelId:          receptorImpl.GetReceptorType(),
 				})
 			}
-			
+
 			// Report evidence discovered in the service provider account
 			if receptor_sdk.FindEvidence {
 				err = report(rc, credentials, config)


### PR DESCRIPTION
# Summary

PR fixes Config receporting back to Trustero when in scan mode run of receptor just like the verify mode.

# Test Plan

Tested  config receptor locally

# Task
[AP-12575]


[AP-12575]: https://intersticelabs.atlassian.net/browse/AP-12575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ